### PR TITLE
Add TargetApi annotation to onConfigure

### DIFF
--- a/src/edu/mit/mobile/android/content/SimpleContentProvider.java
+++ b/src/edu/mit/mobile/android/content/SimpleContentProvider.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import android.annotation.TargetApi;
 import android.app.Application;
 import android.app.SearchManager;
 import android.content.ContentProvider;
@@ -714,6 +715,7 @@ public abstract class SimpleContentProvider extends ContentProvider {
             }
         }
 
+        @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
         @Override
         public void onConfigure(SQLiteDatabase db) {
             super.onConfigure(db);


### PR DESCRIPTION
To stop android lint from raising an error, annotate the onConfigure
override in DatabaseOpenHelper to be JellyBean or higher. Older
android versions will continue to use the old mechanism already checked
for in the onOpen override.
