### PR TITLE
Added build.gradle for Gradle support (Android Studio)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,31 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.5.+'
+    }
+}
+apply plugin: 'android-library'
+
+dependencies {
+}
+
+android {
+    compileSdkVersion 18
+    buildToolsVersion "18.1.0"
+
+    defaultConfig {
+        minSdkVersion 7
+        targetSdkVersion 18
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            res.srcDirs = ['res']
+        }
+    }
+}


### PR DESCRIPTION
I was able to compile the library for use with Gradle and Android Studio as an apk-lib. All that is needed is this build.gradle file that is included in this commit. 

Working great in Android Studio 0.2.11
