### PR TITLE
Added protected getter for mDatabaseHelper.

### DIFF
--- a/src/edu/mit/mobile/android/content/SimpleContentProvider.java
+++ b/src/edu/mit/mobile/android/content/SimpleContentProvider.java
@@ -670,6 +670,15 @@ public abstract class SimpleContentProvider extends ContentProvider {
     protected DatabaseOpenHelper createDatabaseOpenHelper() {
         return new DatabaseOpenHelper(getContext(), mDBName, mDBVersion);
     }
+    
+    /**
+     * Return our instantiated {@link DatabaseOpenHelper} for this provider.
+     * 
+     * @return this providers DatabaseOpenHelper.
+     */
+    protected DatabaseOpenHelper getDatabaseHelper() {
+        return this.mDatabaseHelper;
+    }
 
     // //////////////////// internal classes
 


### PR DESCRIPTION
Added protected getter for mDatabaseHelper.

As mention via email;

"As far as arbitrarily accessing the database from within the provider: unfortunately that variable wasn't exposed to the provider (that's a bug), but you could add a protected getter for it. The field you want is mDatabaseHelper in SimpleContentProvider."
